### PR TITLE
Update VisitGithub.tsx

### DIFF
--- a/components/VisitGithub.tsx
+++ b/components/VisitGithub.tsx
@@ -3,7 +3,7 @@ const VisitGithub = (props: React.ComponentPropsWithoutRef<"p">) => {
     <p {...props}>
       Visit github for&nbsp;
       <a
-        href="https://github.com/talatkuyuk/next-mdx-remote-client-in-pages-router"
+        href="https://github.com/talatkuyuk/next-mdx-remote-client-in-app-router"
         target="_blank"
       >
         source code


### PR DESCRIPTION
the visit on https://next-mdx-remote-client-in-app-router.vercel.app should redirect to [App Demo](https://github.com/talatkuyuk/next-mdx-remote-client-in-app-router) repository, instead it redirects to [Page Demo](https://github.com/talatkuyuk/next-mdx-remote-client-in-pages-router)