### PR TITLE
react components can't start via smallcase

### DIFF
--- a/mdxComponents/pre.tsx
+++ b/mdxComponents/pre.tsx
@@ -5,7 +5,7 @@ import React, { type ElementRef, useRef, useState } from "react";
 import IconContentCopy from "@/components/icons/IconContentCopy";
 import IconDone from "@/components/icons/IconDone";
 
-const pre = (props: React.ComponentPropsWithoutRef<"pre">) => {
+const Pre = (props: React.ComponentPropsWithoutRef<"pre">) => {
   const preRef = useRef<ElementRef<"pre">>(null);
   const [copied, setCopied] = useState(false);
 
@@ -45,4 +45,4 @@ const pre = (props: React.ComponentPropsWithoutRef<"pre">) => {
   );
 };
 
-export default pre;
+export default Pre;


### PR DESCRIPTION
- react components can't start via smallcase
- it will show type error in vscode or any other ide
- solved by just switching pre to Pre
- **no breaking changes**